### PR TITLE
set max-height on card img

### DIFF
--- a/assets/style/style.css
+++ b/assets/style/style.css
@@ -53,3 +53,7 @@ label {
 .layout {
     height: 550px;
 }
+
+.card .card-image img {
+    max-height: 270px;
+}


### PR DESCRIPTION
added max-height to recipe card images to prevent display overflow